### PR TITLE
Update FivemPlayerlist.cs with an internal cache

### DIFF
--- a/FivemPlayerlist/FivemPlayerlist.cs
+++ b/FivemPlayerlist/FivemPlayerlist.cs
@@ -326,7 +326,14 @@ namespace FivemPlayerlist
                         };
                     }
 
-                    row.textureString = textureCache[p.Handle] ?? "";
+                    if (textureCache.ContainsKey(p.Handle))
+                    {
+                        row.textureString = textureCache[p.Handle];
+                    }
+                    else
+                    {
+                        row.textureString = "";
+                    }
                     
                     rows.Add(row);
                 }

--- a/FivemPlayerlist/FivemPlayerlist.cs
+++ b/FivemPlayerlist/FivemPlayerlist.cs
@@ -307,7 +307,6 @@ namespace FivemPlayerlist
                             rightText = $"{p.ServerId}",
                             serverId = p.ServerId,
                         };
-
                     }
                     else
                     {
@@ -326,19 +325,22 @@ namespace FivemPlayerlist
                         };
                     }
 
-                    if (textureCache.ContainsKey(p.Handle))
+                    Debug.WriteLine("Checking if {0} is in the Dic. Their SERVER ID {1}.", p.Name, p.ServerId);
+                    if (textureCache.ContainsKey(p.ServerId))
                     {
-                        row.textureString = textureCache[p.Handle];
+                        row.textureString = textureCache[p.ServerId];
                     }
                     else
                     {
+                        Debug.WriteLine("Not in setting image to blank");
                         row.textureString = "";
                     }
-                    
+
                     rows.Add(row);
                 }
                 amount++;
             }
+            Debug.WriteLine("Sorting rows");
             rows.Sort((row1, row2) => row1.serverId.CompareTo(row2.serverId));
             for (var i = 0; i < maxClients * 2; i++)
             {
@@ -397,7 +399,8 @@ namespace FivemPlayerlist
             {
                 string headshot = await GetHeadshotImage(GetPlayerPed(p.Handle));
 
-                textureCache[p.Handle] = headshot;
+                Debug.WriteLine("Updating " + p.ServerId + " : " + p.Handle);
+                textureCache[p.ServerId] = headshot;
             }
 
             //Maybe make configurable?

--- a/FivemPlayerlist/FivemPlayerlist.cs
+++ b/FivemPlayerlist/FivemPlayerlist.cs
@@ -325,14 +325,14 @@ namespace FivemPlayerlist
                         };
                     }
 
-                    Debug.WriteLine("Checking if {0} is in the Dic. Their SERVER ID {1}.", p.Name, p.ServerId);
+                    //Debug.WriteLine("Checking if {0} is in the Dic. Their SERVER ID {1}.", p.Name, p.ServerId);
                     if (textureCache.ContainsKey(p.ServerId))
                     {
                         row.textureString = textureCache[p.ServerId];
                     }
                     else
                     {
-                        Debug.WriteLine("Not in setting image to blank");
+                        //Debug.WriteLine("Not in setting image to blank");
                         row.textureString = "";
                     }
 
@@ -340,7 +340,6 @@ namespace FivemPlayerlist
                 }
                 amount++;
             }
-            Debug.WriteLine("Sorting rows");
             rows.Sort((row1, row2) => row1.serverId.CompareTo(row2.serverId));
             for (var i = 0; i < maxClients * 2; i++)
             {
@@ -391,15 +390,12 @@ namespace FivemPlayerlist
         /// <returns></returns>
         private async Task UpdateHeadshots()
         {
-            Debug.WriteLine("Updating headshots...");
             PlayerList playersToCheck = new PlayerList();
-            //Debug.WriteLine("Players to check: " + playersToCheck.Count());
 
             foreach (Player p in playersToCheck)
             {
                 string headshot = await GetHeadshotImage(GetPlayerPed(p.Handle));
 
-                Debug.WriteLine("Updating " + p.ServerId + " : " + p.Handle);
                 textureCache[p.ServerId] = headshot;
             }
 


### PR DESCRIPTION
The headshots are popped into another Dictionary that is periodically updated with the latest headshot of the players. This makes pressing `MULTIPLAYER_INFO` nice and fast!

I've also updated your `UpdateScale` function to not repeat the lines
```cs
row.textureString = textureCache[p.Handle] ?? "";
rows.Add(row);
```
It's not needed but, I think it's better as if you want to update it in future you can just change the one line instead of the two. 

With the textures being generated in another task, the original also didn't "await" anything so, I added a `Delay(0)` in there to keep everything happy.